### PR TITLE
new changes in the pages

### DIFF
--- a/core/home/templates/theFacultyEquipmAndSoftware.html
+++ b/core/home/templates/theFacultyEquipmAndSoftware.html
@@ -435,7 +435,7 @@
                     </tr>
                     <tr>
                         <td style="vertical-align:top; width:160px">
-                        <p><a href="https://physics.bsu.by/ru/staff/picevich-georgij-aleksandrovich/"><strong><span style="color:#c00000">Вакуумный атомно-эмиссионный спектрометр ЭМАС200 УН</span></strong></a></p>
+                        <p><a href="https://physics.bsu.by/ru/staff/novickij-andrej-viktorovich/"><strong><span style="color:#c00000">Вакуумный атомно-эмиссионный спектрометр ЭМАС200 УН</span></strong></a></p>
 
                         <p>&nbsp;</p>
 
@@ -489,9 +489,9 @@
                     </tr>
                     <tr>
                         <td style="vertical-align:top; width:160px">
-                        <p><strong><span style="color:#c00000"><a href="https://physics.bsu.by/ru/staff/picevich-georgij-aleksandrovich/"><span style="color:#c00000">Спектрометр высокого разрешения для онлайн дистанционной спектроскопии излучения и поглощения природных сред</span></a></span></strong></p>
+                        <p><strong><span style="color:#c00000"><a href="https://physics.bsu.by/ru/staff/novickij-andrej-viktorovich/"><strong><span style="color:#c00000">Спектрометр высокого разрешения для онлайн дистанционной спектроскопии излучения и поглощения природных сред</span></strong></a></span></strong></p>
 
-                        <p><span><strong><span style="color:#c00000"><a href="https://physics.bsu.by/ru/staff/picevich-georgij-aleksandrovich/"><span style="color:#c00000">MSmL</span><span style="color:#c00000"> 847</span></a></span></strong></span></p>
+                        <p><span><strong><span style="color:#c00000"><a href="https://physics.bsu.by/ru/staff/novickij-andrej-viktorovich/"><strong><span style="color:#c00000">MSmL</span><span style="color:#c00000"> 847</span><strong></a></span></strong></span></p>
 
                         <p>&nbsp;</p>
 
@@ -533,7 +533,7 @@
                     </tr>
                     <tr>
                         <td style="vertical-align:top; width:160px">
-                        <p><a href="https://physics.bsu.by/ru/staff/picevich-georgij-aleksandrovich/"><strong><span style="color:#c00000">Аппаратно-программные комплексы для обработки изображений</span></strong> <strong><span style="color:#c00000">«AUTOSCAN» (металлография), «ГЕОСКАН» (петрография), «БИОСКАН» (медицина и микробиология)</span></strong></a></p>
+                        <p><a href="https://physics.bsu.by/ru/staff/novickij-andrej-viktorovich/"><strong><span style="color:#c00000">Аппаратно-программные комплексы для обработки изображений</span></strong> <strong><span style="color:#c00000">«AUTOSCAN» (металлография), «ГЕОСКАН» (петрография), «БИОСКАН» (медицина и микробиология)</span></strong></a></p>
 
                         <p>&nbsp;</p>
 
@@ -1236,7 +1236,7 @@
 				</tr>
 				<tr>
 					<td style="vertical-align:top; width:160px">
-					<p><a href="https://physics.bsu.by/en/staff/picevich-georgij-aleksandrovich/"><strong><span style="color:#c00000">Vacuum</span></strong><strong> </strong><strong><span style="color:#c00000">atomic</span></strong><strong> </strong><strong><span style="color:#c00000">emission</span></strong><strong> </strong><strong><span style="color:#c00000">spectrometer</span></strong><strong> </strong><strong><span style="color:#c00000">EMAS</span></strong><strong><span style="color:#c00000">200</span></strong><strong><span style="color:#c00000">UN</span></strong></a></p>
+					<p><a href="https://physics.bsu.by/en/staff/novickij-andrej-viktorovich/"><strong><span style="color:#c00000">Vacuum</span></strong><strong> </strong><strong><span style="color:#c00000">atomic</span></strong><strong> </strong><strong><span style="color:#c00000">emission</span></strong><strong> </strong><strong><span style="color:#c00000">spectrometer</span></strong><strong> </strong><strong><span style="color:#c00000">EMAS</span></strong><strong><span style="color:#c00000">200</span></strong><strong><span style="color:#c00000">UN</span></strong></a></p>
 
 					<p>&nbsp;</p>
 
@@ -1288,7 +1288,7 @@
 				</tr>
 				<tr>
 					<td style="vertical-align:top; width:160px">
-					<p><a href="https://physics.bsu.by/en/staff/picevich-georgij-aleksandrovich/"><strong><span style="color:#c00000">MSmL 847</span></strong><strong><span style="color:#c00000"> h</span></strong><strong><span style="color:#c00000">igh</span></strong><strong><span style="color:#c00000">-</span></strong><strong><span style="color:#c00000">resolution</span></strong><strong> </strong><strong><span style="color:#c00000">spectrometer</span></strong><strong> </strong><strong><span style="color:#c00000">for</span></strong><strong> </strong><strong><span style="color:#c00000">online</span></strong><strong> </strong><strong><span style="color:#c00000">remote</span></strong><strong> </strong><strong><span style="color:#c00000">radiation and absorption </span></strong><strong><span style="color:#c00000">spectroscopy</span></strong><strong> </strong><strong><span style="color:#c00000">of</span></strong><strong> </strong><strong><span style="color:#c00000">natural</span></strong><strong> </strong><strong><span style="color:#c00000">media</span></strong></a></p>
+					<p><a href="https://physics.bsu.by/en/staff/novickij-andrej-viktorovich/"><strong><span style="color:#c00000">MSmL 847</span></strong><strong><span style="color:#c00000"> h</span></strong><strong><span style="color:#c00000">igh</span></strong><strong><span style="color:#c00000">-</span></strong><strong><span style="color:#c00000">resolution</span></strong><strong> </strong><strong><span style="color:#c00000">spectrometer</span></strong><strong> </strong><strong><span style="color:#c00000">for</span></strong><strong> </strong><strong><span style="color:#c00000">online</span></strong><strong> </strong><strong><span style="color:#c00000">remote</span></strong><strong> </strong><strong><span style="color:#c00000">radiation and absorption </span></strong><strong><span style="color:#c00000">spectroscopy</span></strong><strong> </strong><strong><span style="color:#c00000">of</span></strong><strong> </strong><strong><span style="color:#c00000">natural</span></strong><strong> </strong><strong><span style="color:#c00000">media</span></strong></a></p>
 
 					<p>&nbsp;</p>
 
@@ -1330,7 +1330,7 @@
 				</tr>
 				<tr>
 					<td style="vertical-align:top; width:160px">
-					<p><a href="https://physics.bsu.by/en/staff/picevich-georgij-aleksandrovich/"><strong><span style="color:#c00000">Hardware-software complexes for image processing AUTOSCAN (metallography), GEOSCAN (petrography), BIOSCAN (medicine and microbiology)</span></strong></a></p>
+					<p><a href="https://physics.bsu.by/en/staff/novickij-andrej-viktorovich/"><strong><span style="color:#c00000">Hardware-software complexes for image processing AUTOSCAN (metallography), GEOSCAN (petrography), BIOSCAN (medicine and microbiology)</span></strong></a></p>
 
 					<p>&nbsp;</p>
 

--- a/core/home/templates/theFacultyEquipmAndSoftware.html
+++ b/core/home/templates/theFacultyEquipmAndSoftware.html
@@ -17,7 +17,7 @@
                 <p><strong>В настоящем каталоге представлен список разработанного на физическом&nbsp;факультете Белорусского государственного университета оборудования и программного обеспечения, доступного к заказу</strong></p>
             </li>
             <li style="padding-bottom:15px;">
-                <p><strong>Вы можете скачать <a download="" href="https://physics.bsu.by/media/media/_Spisok_razrabotok_fizicheskogo_fakulteta_BGU_2022.pdf" style="display:inline!important; font-weight:bold;" id="link-equip-softw-1">список разработок в формате&nbsp;PDF</a></strong></p>
+                <p><strong>Вы можете скачать <a download="" href="https://physics.bsu.by/media/media/_Spisok-razrabotok-fizicheskogo-fakulteta-BGU-2022_2.pdf" style="display:inline!important; font-weight:bold;" id="link-equip-softw-1">список разработок в формате&nbsp;PDF</a></strong></p>
             </li>
             <li style="padding-bottom:15px;">
                 <p><strong>В наименованиях приведены ссылки на контактные&nbsp;данные заведующих кафедрами / лабораториями, где созданы указанные разработки</strong></p>
@@ -819,7 +819,7 @@
                 <p><strong>This&nbsp;catalog contains the&nbsp;list of equipment and software developed at the&nbsp;Faculty&nbsp;of&nbsp;Physics of the&nbsp;Belarusian State&nbsp;University and available for&nbsp;purchase</strong></p>
             </li>
             <li style="padding-bottom:15px;">
-                <p><strong>You can <a id="link-equip-softw-1" download="" href="https://physics.bsu.by/media/media/_List_of_Equipment_and_Software_-_BSU_Faculty_of_Physics_2022.pdf" style="display:inline!important; font-weight:bold;">download this&nbsp;list in&nbsp;PDF</a></strong></p>
+                <p><strong>You can <a id="link-equip-softw-1" download="" href="https://physics.bsu.by/media/media/_List_of_Equipment_and_Software_-_BSU_Faculty_of_Physics_2022_2.pdf" style="display:inline!important; font-weight:bold;">download this&nbsp;list in&nbsp;PDF</a></strong></p>
             </li>
             <li style="padding-bottom:15px;">
                 <p><strong>The&nbsp;names of the&nbsp;developments contain links to the&nbsp;contact&nbsp;details of the&nbsp;Heads of&nbsp;the Departments / Laboratories where the&nbsp;specified unit is made</strong></p>

--- a/core/home/templates/theFacultyServices.html
+++ b/core/home/templates/theFacultyServices.html
@@ -17,7 +17,7 @@
                 <p><strong>В настоящем каталоге приводится список услуг, которые могут быть оказаны физическим&nbsp;факультетом БГУ в рамках прямых договоров&nbsp;(контрактов)</strong></p>
             </li>
             <li style="padding-bottom:15px;">
-                <p><strong>Вы можете скачать <a id="link-services" download="" href="https://physics.bsu.by/media/media/_Spisok-uslug-fizicheskogo-fakulteta-BGU-2022_3.pdf" style="display:inline!important; font-weight:bold;">список услуг в формате&nbsp;PDF</a></strong></p>
+                <p><strong>Вы можете скачать <a id="link-services" download="" href="https://physics.bsu.by/media/media/_Spisok-uslug-fizicheskogo-fakulteta-BGU-2022_4.pdf" style="display:inline!important; font-weight:bold;">список услуг в формате&nbsp;PDF</a></strong></p>
             </li>
             <li style="padding-bottom:15px;">
                 <p><strong>В наименованиях&nbsp;услуг представлены ссылки на контактные данные заведующих&nbsp;кафедрами, где проводятся указанные работы</strong></p>
@@ -996,7 +996,7 @@
                 <p><strong>This&nbsp;catalog contains the list of science-intensive services that can be provided by the&nbsp;Faculty&nbsp;of&nbsp;Physics under the&nbsp;direct&nbsp;agreements (contracts)</strong></p>
             </li>
             <li style="padding-bottom:15px;">
-                <p><strong>You can <a id="link-services" download="" href="https://physics.bsu.by/media/media/_List_of_Services_-_BSU_Faculty_of_Physics_2022.pdf" style="display:inline!important; font-weight:bold;">download this list in&nbsp;PDF</a></strong></p>
+                <p><strong>You can <a id="link-services" download="" href="https://physics.bsu.by/media/media/_List_of_Services_-_BSU_Faculty_of_Physics_2022_1.pdf" style="display:inline!important; font-weight:bold;">download this list in&nbsp;PDF</a></strong></p>
             </li>
             <li style="padding-bottom:15px;">
                 <p><strong>The names of the&nbsp;services contain links to the contact details of the&nbsp;Heads&nbsp;of the&nbsp;Departments where the specified work is carried out</strong></p>

--- a/core/home/templates/theFacultyServices.html
+++ b/core/home/templates/theFacultyServices.html
@@ -801,7 +801,7 @@
                         <p><strong>Молекулярные расчеты</strong></p>
                     </td>
                     <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; vertical-align:top; width:236px">
-                        <p><a href="https://physics.bsu.by/ru/staff/picevich-georgij-aleksandrovich/"><span>Анализ внутреннего вращения в молекулах с несколькими волчками</span></a></p>
+                        <p><a href="https://physics.bsu.by/ru/staff/novickij-andrej-viktorovich/"><span>Анализ внутреннего вращения в молекулах с несколькими волчками</span></a></p>
                     </td>
                     <td rowspan="3" style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; vertical-align:top; width:340px">
                         <p>Моделирование параметров молекулярных систем с использованием программных пакетов <strong>GAMESS</strong> и <strong>ORCA</strong>; для больших амплитуд используются <strong>собственные разработки в среде</strong> <strong>Wolfram Mathematica</strong>; расчеты параметров двухатомных молекул производятся многоконфигурационными методами с привлечением комплекта <strong>ActiveSpace</strong>.</p>
@@ -812,7 +812,7 @@
                 </tr>
                 <tr>
                     <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; vertical-align:top; width:236px">
-                        <p><a href="https://physics.bsu.by/ru/staff/picevich-georgij-aleksandrovich/"><span>Расчеты спектрально-структурных характеристик комплексов и кластеров с водородными связями</span></a></p>
+                        <p><a href="https://physics.bsu.by/ru/staff/novickij-andrej-viktorovich/"><span>Расчеты спектрально-структурных характеристик комплексов и кластеров с водородными связями</span></a></p>
                     </td>
                     <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:151px">
                         <p><em>5&nbsp;000 – 10&nbsp;000 за комплект расчетов</em></p>
@@ -820,7 +820,7 @@
                 </tr>
                 <tr>
                     <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; vertical-align:top; width:236px">
-                        <p><a href="https://physics.bsu.by/ru/staff/picevich-georgij-aleksandrovich/"><span>Расчёты функций потенциальной энергии нижних электронных состояний, а также молекулярных спектроскопических постоянных и радиационных характеристик двухатомных молекул, перспективных для лазерного охлаждения</span></a></p>
+                        <p><a href="https://physics.bsu.by/ru/staff/novickij-andrej-viktorovich/"><span>Расчёты функций потенциальной энергии нижних электронных состояний, а также молекулярных спектроскопических постоянных и радиационных характеристик двухатомных молекул, перспективных для лазерного охлаждения</span></a></p>
                     </td>
                     <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:151px">
                         <p><em>3&nbsp;000 – 10&nbsp;000 за комплект расчетов</em></p>
@@ -1788,7 +1788,7 @@
                         <p><strong>Molecular calculations</strong></p>
                         </td>
                         <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; vertical-align:top; width:236px">
-                        <p><a href="https://physics.bsu.by/en/staff/picevich-georgij-aleksandrovich/">Analysis of internal rotation in molecules with multiple tops</a></p>
+                        <p><a href="https://physics.bsu.by/en/staff/novickij-andrej-viktorovich/">Analysis of internal rotation in molecules with multiple tops</a></p>
                         </td>
                         <td rowspan="3" style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; vertical-align:top; width:340px">
                         <p>Modeling of molecular system parameters using <strong>GAMESS</strong> and <strong>ORCA</strong> software packages; for large amplitudes, <strong>own developments in the</strong> <strong>Wolfram Mathematica</strong> <strong>environment</strong> are used; the parameters of diatomic molecules are calculated by multiconfiguration methods using the <strong>ActiveSpace</strong> kit.</p>
@@ -1801,7 +1801,7 @@
                     </tr>
                     <tr>
                         <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; vertical-align:top; width:236px">
-                        <p><a href="https://physics.bsu.by/en/staff/picevich-georgij-aleksandrovich/">Calculations of spectral and structural characteristics of complexes and clusters with hydrogen bonds</a></p>
+                        <p><a href="https://physics.bsu.by/en/staff/novickij-andrej-viktorovich/">Calculations of spectral and structural characteristics of complexes and clusters with hydrogen bonds</a></p>
                         </td>
                         <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:151px">
                         <p><em>2&nbsp;000 &ndash; 4&nbsp;000</em></p>
@@ -1811,7 +1811,7 @@
                     </tr>
                     <tr>
                         <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; vertical-align:top; width:236px">
-                        <p><a href="https://physics.bsu.by/en/staff/picevich-georgij-aleksandrovich/">Calculations of the potential energy functions of the lower electronic states, as well as molecular spectroscopic constants and radiation characteristics of diatomic molecules for laser cooling</a></p>
+                        <p><a href="https://physics.bsu.by/en/staff/novickij-andrej-viktorovich/">Calculations of the potential energy functions of the lower electronic states, as well as molecular spectroscopic constants and radiation characteristics of diatomic molecules for laser cooling</a></p>
                         </td>
                         <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:151px">
                         <p><em>1&nbsp;000 &ndash; 4&nbsp;000</em></p>


### PR DESCRIPTION
theFacultyServices.html, theFacultyEquipmAndSoftware.html
- the links paths changed for the RU-lang vers. of the page ('https://physics.bsu.by/ru/staff/picevich-georgij-aleksandrovich/' replaced with 'https://physics.bsu.by/ru/staff/novickij-andrej-viktorovich/')
- the links paths changed for the ENG-lang vers. of the page ('https://physics.bsu.by/en/staff/picevich-georgij-aleksandrovich/' replaced with 'https://physics.bsu.by/en/staff/novickij-andrej-viktorovich/')


theFacultyServices.html
- the current link path to the pdf-file of the list of the Faculty services deleted, the new one added


theFacultyEquipmAndSoftware.html
- the current link path to the pdf-file of the list of the Faculty equipment and software deleted, the new one added