### PR TITLE
new changes in the page

### DIFF
--- a/core/home/templates/PublicationsAll.html
+++ b/core/home/templates/PublicationsAll.html
@@ -146,7 +146,7 @@
                         id="svg-4e56" style="enable-background:new 0 0 490.656 490.656;"><g><g><path d="M487.536,120.445c-4.16-4.16-10.923-4.16-15.083,0L245.339,347.581L18.203,120.467c-4.16-4.16-10.923-4.16-15.083,0    c-4.16,4.16-4.16,10.923,0,15.083l234.667,234.667c2.091,2.069,4.821,3.115,7.552,3.115s5.461-1.045,7.531-3.136l234.667-234.667    C491.696,131.368,491.696,124.605,487.536,120.445z"></path></g>
 </g></svg></span>
                 </a>
-                <div class="u-accordion-active u-accordion-pane u-align-left u-container-style u-accordion-pane-1"
+                <div class="u-accordion-pane u-align-left u-container-style u-accordion-pane-2"
                      id="accordion-5k1m" aria-labelledby="link-accordion-5k1m">
                     <div class="u-container-layout u-container-layout-1">
                         <p class="u-text u-text-default u-text-1">

--- a/core/home/templates/PublicationsAll.html
+++ b/core/home/templates/PublicationsAll.html
@@ -133,7 +133,7 @@
             </div>
 
             <div class="u-accordion-item">
-                <a class="u-accordion-link u-active-custom-color-2 u-border-1 u-border-active-black u-border-black u-border-hover-black u-button-style u-hover-custom-color-2 u-text-active-black u-text-hover-black u-white u-accordion-link-1"
+                <a class="u-accordion-link u-active-custom-color-2 u-border-1 u-border-active-black u-border-black u-border-hover-black u-button-style u-hover-custom-color-2 u-text-active-black u-text-hover-black u-white u-accordion-link-2"
                    id="link-accordion-5k1m" aria-controls="accordion-5k1m" aria-selected="false">
               <span class="u-accordion-link-text">{% if LANGUAGE_CODE == "ru"%}<b>ПУБЛИКАЦИИ В SCOPUS ЗА 2022 ГОД</b>{% endif %}{% if LANGUAGE_CODE == "en"%}<b>PUBLICATIONS IN SCOPUS FOR 2022</b>{% endif %}&nbsp;
               </span><span class="u-accordion-link-icon u-icon u-text-grey-40 u-icon-1"><svg class="u-svg-link"


### PR DESCRIPTION
PublicationsAll.html
- specially replaced all names in the class attribute of the inner 'div' section (the Scopus publications for 2022 tab)
- correction in the link class name