### PR TITLE
new changes in the page

### DIFF
--- a/core/home/templates/nilAndScienceDir.html
+++ b/core/home/templates/nilAndScienceDir.html
@@ -283,7 +283,7 @@
         <div class="person_template_float_wrap col-lg-12 col-md-12 col-sm-12 col-xs-12 box_research-dir-info" style="display:flex;">
             <img class="col-lg-6 col-md-6 col-sm-12 col-xs-12 directions-img" style="max-width:172px!important; align-self:center!important; height:140px" src="{% static 'home/assets/images/IMAGES_SCI/_19_ENERG.jpg' %}" alt="">
             <div>
-                <div class="person_template_title direction-title" ><a href="https://physics.bsu.by/ru/departments/kafedra-energofiziki/" style="font-size:23px">{% trans "ЭНЕРГОФИЗИКА" %}</a></div>
+                <div class="person_template_title direction-title" ><a href="https://physics.bsu.by/ru/departments/kafedra-fiziki-tverdogo-tela/" style="font-size:23px">{% trans "ЭНЕРГОФИЗИКА" %}</a></div>
                 <div class="person_template_text" >
                     <p>
                         {% trans "· материалы солнечной энергетики" %}<br>


### PR DESCRIPTION
nilAndScienceDir.html
- the current link path in the 'a'-html block "ЭНЕРГОФИЗИКА" replaced with the new one