### PR TITLE
new changes in the pages

### DIFF
--- a/core/home/templates/5.html
+++ b/core/home/templates/5.html
@@ -16,7 +16,7 @@
         <a href="https://physics.bsu.by/ru/stars/">{% trans "Учебно-научная астрономическая лаборатория" %}</a>
         <a href="/raspred/">{% trans "Распределение" %}</a>
         <a href="/tutor/">{% trans "Тьюторская служба факультета" %}</a>
-        <a href="http://www.physics.bsu.by/sites/all/other/info/index.php">{% trans "Учебно-методические материалы (PhysInfo)" %}</a>
+        <a href="#">{% trans "Учебно-методические материалы (PhysInfo)" %}</a>
         <a href="/olimp2021/">{% trans "Студенческая олимпиада" %}</a>
         <a href="/pravila-pr/">{% trans "Правила педагогических работников" %}</a>
     </div>

--- a/core/home/templates/header.html
+++ b/core/home/templates/header.html
@@ -807,7 +807,7 @@
                 <a href="/stars/">{% trans "Учебно-научная астрономическая лаборатория" %}</a>
                 <a href="/raspred/">{% trans "Распределение" %}</a>
                 <a href="/tutor/">{% trans "Тьюторская служба факультета" %}</a><!-- Вариант перевода на английский язык: 'Tutor service of the Faculty' -->
-                <a href="http://www.physics.bsu.by/sites/all/other/info/index.php">{% trans "Учебно-методические материалы" %}</a>
+                <a href="#">{% trans "Учебно-методические материалы" %}</a>
                 <a href="olimp2021/">{% trans "Студенческая олимпиада" %}</a>
                 <a href="/pravila-pr/">{% trans "Правила педагогических работников" %}</a>
             </div>

--- a/core/home/templates/header_6.html
+++ b/core/home/templates/header_6.html
@@ -713,7 +713,7 @@
                 <a href="/stars/">{% trans "Учебно-научная астрономическая лаборатория" %}</a>
                 <a href="/raspred/">{% trans "Распределение" %}</a>
                 <a href="/tutor/">{% trans "Тьюторская служба факультета" %}</a><!-- Вариант перевода на английский язык: 'Tutor service of the Faculty' -->
-                <a href="http://www.physics.bsu.by/sites/all/other/info/index.php">{% trans "Учебно-методические материалы" %}</a>
+                <a href="#">{% trans "Учебно-методические материалы" %}</a>
                 <a href="/olimp2021/">{% trans "Студенческая олимпиада" %}</a>
                 <a href="/pravila-pr/">{% trans "Правила педагогических работников" %}</a>
             </div>


### PR DESCRIPTION
5.html
- the current incorrect link path for "Учебно-методические материалы (PhysInfo)" deleted and 'hashed'

header.html, header_6.html
- the current incorrect link path for "Учебно-методические материалы" deleted and 'hashed'